### PR TITLE
fix: typo error

### DIFF
--- a/components/NavBarBeta.tsx
+++ b/components/NavBarBeta.tsx
@@ -257,7 +257,7 @@ const NavBarBeta = () => {
                             Liquidator Program
                           </p>
                           <p className="mt-1 text-sm text-gray-500">
-                            Help safegaurd the mango protocol, become a
+                            Help safeguard the mango protocol, become a
                             decentralized liquidator.
                           </p>
                         </div>


### PR DESCRIPTION
fix typo mistake for the word `safeguard` found on product drop down
<img width="1203" alt="mango-market-web-typo" src="https://user-images.githubusercontent.com/8136256/140630913-9221280a-c7ad-435f-8e3c-335ee09b4006.png">

